### PR TITLE
Add Swedish repo overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
-# AI-Workshops
+# 🧠 DDI AI-Agent Repository
+
+Detta är vår interna kunskapsbas, verktygslåda och experimentmiljö för allt som rör AI-agenter, prompt engineering och agentifiering – inom ramen för Data-driven Innovation (DDI) på Chalmers Industriteknik.
+
+## 📍 Syfte
+
+Repo:t fungerar som:
+
+- 📚 En **kunskapsbas**: vårt kollektiva språk, begrepp och förståelse.
+- 🧰 En **verktygslåda**: workshops, mallar, övningar och metoder.
+- 🔬 Ett **experimentfält**: platsen där vi testar, bygger, promptar, sparar.
+- 🔗 Ett **resurslager**: länkar, kod, externa referenser, papers, demos.
+
+Allt detta ska gå att återanvända, dela, och bygga vidare på.
+
+## 🗂 Strukturen
+
+### `/01_workshops/`  
+Här ligger alla mallar och körbara workshops.  
+Exempel: upplägg för “Agent Cooking Class”, övningar i att designa sin egen agent, prompt-lekar, faciliteringsguider.
+
+### `/02_kunskapsbas/`  
+Vår egenformulerade kunskap.  
+Här beskriver vi med egna ord vad en agent är, hur agentifiering funkar, hur promptteknik används, hur vi tolkar och tillämpar tekniker. Det är **vår röst, vår förståelse.**
+
+### `/03_resources/`  
+Här sparar vi externa resurser: länkar, papers, kodsnuttar, videos, APIer, artiklar – sånt vi använder som referens eller bygger vidare på.  
+Hit slänger vi saker först. Sortering kommer sen.
+
+### `/04_experiments/`  
+Här bor våra halvfärdiga idéer, prompttester, agentutkast, systemflöden, kodfragment.  
+Detta är en sandbox. Struktur är sekundärt. Allt som inte passar någon annanstans – dumpa det här.
+
+## 🧭 Hur använder jag repo:t?
+
+- Hittar du en resurs? → Lägg i `/03_resources/` (t.ex. `multi-agent-systems-anthropic.webloc`)
+- Vill du beskriva en metod? → Skriv i `/02_kunskapsbas/` (t.ex. `agentifiering-av-team.md`)
+- Ska du leda workshop? → Hämta från `/01_workshops/` eller skapa en ny mall
+- Vill du leka med prompts, bygga en agent eller testa? → Gå loss i `/04_experiments/`
+
+## 🧑‍🤝‍🧑 Förhållningssätt
+
+- Dumpa först. Strukturera senare.
+- Vi skriver för varandra – inga utifrånblickar här.
+- Vi bygger för att förstå, inte för att leverera perfektion.
+- Vårt språk ska vara precist men mänskligt. Tänk: “vad hade jag behövt läsa för att fatta det här?”
+
+## 🔄 Under utveckling
+
+Repo:t är levande. Det kommer ändras. Men denna struktur är tänkt att hålla över tid. Om något skaver – notera det i en `README.md` eller skapa en `todo.md` i relevant mapp.
+
+---
+
+**/ddi-agents-repo**  
+Chalmers Industriteknik – Data-driven Innovation  
+2025


### PR DESCRIPTION
## Summary
- replace placeholder README with detailed repo overview in Swedish

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685289649cf48333826aa4ee79e13c09