### PR TITLE
Add workshop README

### DIFF
--- a/01_workshops/README.md
+++ b/01_workshops/README.md
@@ -1,0 +1,102 @@
+# 🛠️ 01_workshops – Workshopstruktur och exekverbara format
+
+Den här mappen innehåller allt material för att **planera, facilitera och vidareutveckla workshops** kopplade till AI-agenter, agentifiering, prompt engineering och datadriven intelligens.
+
+Syftet är att samla **modulärt, återanvändbart och adaptivt** material som kan användas i olika sammanhang: internt lärande, extern kundworkshop, strategiarbete, testmiljö.
+
+---
+
+## 📦 Kategorier av workshops
+
+### [[workshop_overview.md]]
+En översikt över alla tillgängliga workshops och moduler – vad de är, när de används, för vem.
+
+---
+
+### 🧭 1. Introduktion och orientering
+
+- [[what_is_ai_agents.md]] – Vad är en agent egentligen?
+- [[agentic_thinking.md]] – Hur börjar man tänka agentbaserat?
+- [[from_prompt_to_agent.md]] – En introduktion till hela kedjan: prompt → agent → system
+
+---
+
+### 🧰 2. Byggande och experiment
+
+- [[agent_cooking_class.md]] – Steg-för-steg-agentbygge via matlagningsmetafor
+- [[build_your_own_agent.md]] – Praktisk hands-on-session: från behov → roll → funktion
+- [[prompt_to_system_workshop.md]] – Designa ett system från enkla prompts till orkestrerat flöde
+
+---
+
+### 🧠 3. Metakognition och själv-agentifiering
+
+- [[agentify_yourself.md]] – Deltagarna modellerar sig själva som agenter
+- [[instructional_design_via_agents.md]] – Hur man bygger instruktioner för både människa och maskin
+- [[role_extraction_sprint.md]] – Identifiera roller i ett team och agentifiera dem
+
+---
+
+### 🕸 4. Multi-agent & A2A-interaktion
+
+- [[multi_agent_design_sprint.md]] – Designa flöden där flera agenter samarbetar
+- [[agent_to_agent_dialogue.md]] – Simulera konversation mellan två agenter
+- [[conflict_resolution_between_agents.md]] – Testa hur agenter kan ha olika mål men samarbeta
+
+---
+
+### 🧪 5. Experimentella format
+
+- [[theatre_based_workshop.md]] – Workshops som teater: manus, roller, improvisation
+- [[farm_to_fork_ai.md]] – Matkedjemetafor: från data till intelligent system
+- [[sandbox_simulation.md]] – Öppen experimentmiljö där deltagarna får testa vad som helst
+
+---
+
+### 🧩 6. Komponentworkshops (för integration)
+
+Dessa är byggda för att kunna kopplas in i andra sammanhang.
+
+- [[system_prompt_literacy.md]] – Hur man designar ett bra system prompt
+- [[mcp_agent_flowbuilder.md]] – Introduktion till att jobba med MCP-ramverk
+- [[data_to_prompt_workshop.md]] – Hur man går från rådata till promptstruktur
+
+---
+
+## 📎 Gemensamma resurser
+
+Gemensamma mallar, slides och övningsunderlag länkas här:
+
+- [[facilitation_guide.md]] – Hur du leder dessa workshops
+- [[agent_canvas_template.md]] – Canvas för att designa en agent
+- [[session_checklist.md]] – Vad du behöver förbereda före varje workshop
+- [[feedback_loop_guide.md]] – Hur du samlar in, analyserar och itererar på feedback
+
+---
+
+## 📘 Användning
+
+Varje workshop har ett eget `.md`-dokument med:
+
+- Syfte & målgrupp
+- Tidsåtgång & material
+- Förberedelser
+- Steg-för-steg-flöde
+- Variationsmöjligheter
+- Koppling till [[kunskapsbasen]] och [[resources]]
+
+---
+
+## 🧭 Nästa steg
+
+- [ ] Skapa en `[[workshop_overview.md]]` som fungerar som index och tabell
+- [ ] Flytta in eventuella existerande kladdar från Notes eller experiments
+- [ ] Identifiera vilka workshops som redan finns dokumenterade
+- [ ] Markera vilka som behöver testas internt innan extern leverans
+
+---
+
+**→ Se även:**  
+[[02_kunskapsbas/agentifiering-av-team.md]]  
+[[03_resources/openai-agents-readme.md]]  
+[[04_experiments/promptchain-agent-concept.md]]


### PR DESCRIPTION
## Summary
- add README outlining workshop categories and modules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68528a0e4904833388295ba5b5a23740