### PR TITLE
Fix all wikilinks to use correct GitHub wiki format

### DIFF
--- a/02_kunskapsbas/README.md
+++ b/02_kunskapsbas/README.md
@@ -20,31 +20,31 @@ Det är inte en samling länkar. Det är **ett sätt att tänka tillsammans.** �
 
 Alla filer här ligger på toppnivå eller i underkategorier om det växer.
 
-### 🧠 [[vad-är-en-agent.md]]
+### 🧠 [[vad-är-en-agent]]
 Definition, begrepp, skillnad mot chatbot, LLM, API eller verktyg.  
 Vi sätter ramarna för hur *vi* använder ordet "agent".
 
-### 🧬 [[agentifiering.md]]
+### 🧬 [[agentifiering]]
 Vad innebär det att agentifiera ett team, en roll, en individ eller en process?  
 Skillnad mellan förstärkning (augmentation) och automatisering.
 
-### 💡 [[prompt-teknik.md]]
+### 💡 [[prompt-teknik]]
 Hur använder vi språk för att styra agenter?  
 Promptmönster, roller, tonalitet, systeminstruktioner och verktygsintegration.
 
-### 🎭 [[systemprompter.md]]
+### 🎭 [[systemprompter]]
 Vad är ett system prompt i praktiken?  
 Skillnader mellan plattforms-promptar, custom instructions och orkestrering.
 
-### 🛠️ [[agentarkitektur.md]]
+### 🛠️ [[agentarkitektur]]
 Hur bygger man ett agentsystem?  
 Beskrivning av rollstruktur (t.ex. Orkestratör, Verkställare, Kritiker), planeringslogik, loopar, kommunikationsgränssnitt.
 
-### 🕸 [[multi-agent-system.md]]
+### 🕸 [[multi-agent-system]]
 Hur agenter samverkar: A2A, koordination, konflikthantering, orkestrering.  
 Här går vi även in på MCP, RAG, och exempel på multi-agentmönster.
 
-### 🧭 [[agent-to-human-flow.md]]
+### 🧭 [[agent-to-human-flow]]
 Human-in-the-loop som designprincip:  
 Hur fungerar feedbackloopar, mellanlagring, människa som reflektor.
 
@@ -62,8 +62,8 @@ Hur fungerar feedbackloopar, mellanlagring, människa som reflektor.
 ## 🧰 Användningstips
 
 - Om du skriver en ny .md-fil – använd [[Wikilinks]] till andra delar i repo:t om relevant.
-- Om du vill länka till resurser, gör det till [[../03_resources]] eller direkt i texten.
-- Har du en tanke som inte passar här? Lägg den i [[../04_experiments]] först.
+- Om du vill länka till resurser, gör det till [[03_resources/README]] eller direkt i texten.
+- Har du en tanke som inte passar här? Lägg den i [[04_experiments/README]] först.
 
 ---
 

--- a/03_resources/README.md
+++ b/03_resources/README.md
@@ -5,7 +5,7 @@ Här samlar vi **material som vi själva inte skapat**, men som är relevant fö
 Det kan vara länkar, artiklar, kodsnuttar, videos, papers, notebooks, API-dokumentation eller annat som vi använt, vill återkomma till eller bygga vidare på.
 
 🧲 *Denna mapp fungerar som vårt externa minne.*  
-Dumpa här först – sedan bearbetar vi i [[../02_kunskapsbas]] om/när det behövs.
+Dumpa här först – sedan bearbetar vi i [[02_kunskapsbas/README]] om/när det behövs.
 
 ---
 
@@ -34,15 +34,15 @@ Dumpa här först – sedan bearbetar vi i [[../02_kunskapsbas]] om/när det beh
 
 - Ge varje resurs ett eget `.md`-kort om det inte är en fil. T.ex. `anthropic-multi-agent.md` → innehåller länk, beskrivning, ev. citat eller "varför den är relevant"
 - Om det är en fil – döp den tydligt: `openai-agent-api.pdf`, `ng-langchain-talk.webloc`
-- Om du planerar att skriva om den i kunskapsbasen, länka dit med `[[../02_kunskapsbas/flödesarkitektur.md]]` eller liknande.
+- Om du planerar att skriva om den i kunskapsbasen, länka dit med `[[02_kunskapsbas/flödesarkitektur]]` eller liknande.
 
 ---
 
 ## 🔄 Vad som INTE hör hemma här (direkt)
 
-- Våra egna texter och slutsatser → [[../02_kunskapsbas]]
-- Färdiga workshops → [[../01_workshops]]
-- Prompttester → [[../04_experiments]]
+- Våra egna texter och slutsatser → [[02_kunskapsbas/README]]
+- Färdiga workshops → [[01_workshops/README]]
+- Prompttester → [[04_experiments/README]]
 
 Men! Du får gärna referera hitifrån dit – det är så vi bygger ett sammanhängande ekosystem.
 
@@ -56,9 +56,9 @@ När du hittar något viktigt:
 3. Länka vidare till andra delar av repo:t om det passar
 
 > Exempel:  
-> [[openai-agents-readme.md]]  
-> [[anthropic-multi-agent.md]]  
-> [[mcp-component-demo.ipynb]]
+> [[openai-agents-readme]]  
+> [[anthropic-multi-agent]]  
+> [[mcp-component-demo]]
 
 ---
 

--- a/04_experiments/README.md
+++ b/04_experiments/README.md
@@ -36,15 +36,15 @@ Allt är tillåtet – så länge det kan hjälpa dig eller någon annan framåt
 - Skriv gärna i toppen av filen:  
   `Status: idé / pågående / klar för flytt / tänkt till workshop`
 - Lägg gärna till länkar tillbaka till andra mappar om det blir något av det:  
-  "Den här prompten kanske passar i [[../01_workshops/prompt-to-system-workshop.md]]"
+  "Den här prompten kanske passar i [[01_workshops/prompt-to-system-workshop]]"
 
 ---
 
 ## 📘 Vad som INTE hör hemma här (när det mognat)
 
-- Klara mallar → [[../01_workshops]]  
-- Bearbetad teori → [[../02_kunskapsbas]]  
-- Externa länkar → [[../03_resources]]
+- Klara mallar → [[01_workshops/README]]  
+- Bearbetad teori → [[02_kunskapsbas/README]]  
+- Externa länkar → [[03_resources/README]]
 
 Men det får *börja här*. Många filer kommer födas här innan de hamnar någon annanstans. Så funkar det.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Vill du redigera, men är osäker på hur?
 
 ## 📁 Mappstruktur
 
-### [[01_workshops]]
+### [[01_workshops/README]]
 Allt som rör faciliterade format: mallar, övningar, guider, agent-canvas, instruktioner.  
 Vi kommer använda denna mapp i olika workshopformat, både internt och externt.
 
@@ -39,7 +39,7 @@ Vi kommer använda denna mapp i olika workshopformat, både internt och externt.
 
 ---
 
-### [[02_kunskapsbas]]
+### [[02_kunskapsbas/README]]
 Här skriver vi ner det vi själva förstår, lär ut och jobbar med:  
 agentdefinitioner, promptlogik, flödesmönster, språkmodeller, arkitekturprinciper.
 
@@ -47,13 +47,13 @@ Detta är vår pedagogiska och praktiska dokumentation 📘
 
 ---
 
-### [[03_resources]]
+### [[03_resources/README]]
 Extern input: länkar, artiklar, videos, papers, kodfragment, API:er.  
 Allt vi vill spara men inte själva skrivit. Det här är vårt referensbibliotek 🔗
 
 ---
 
-### [[04_experiments]]
+### [[04_experiments/README]]
 Prompttester, agentutkast, halvfärdiga flöden.  
 Här sparas det vi testar, bygger och vill återkomma till. Inget behöver vara färdigt här 🔬
 


### PR DESCRIPTION
- Remove ../ from all wikilinks (use absolute paths from root)
- Remove file extensions (.md, .ipynb) from links
- Fix directory links to point to README files explicitly
- Ensure all cross-directory links use proper format

🤖 Generated with [Claude Code](https://claude.ai/code)