### PR TITLE
Update documentation to clarify workflow and automation vision

### DIFF
--- a/01_workshops/README.md
+++ b/01_workshops/README.md
@@ -1,8 +1,13 @@
-# 🛠️ 01_workshops – Workshopstruktur och exekverbara format
+# 🎯 01_workshops – Production Ready Material
 
-Den här mappen innehåller allt material för att **planera, facilitera och vidareutveckla workshops** kopplade till AI-agenter, agentifiering, prompt engineering och datadriven intelligens.
+**⚠️ VIKTIGT: Endast färdiga, kvalitetssäkrade workshopdokument här!**
 
-Syftet är att samla **modulärt, återanvändbart och adaptivt** material som kan användas i olika sammanhang: internt lärande, extern kundworkshop, strategiarbete, testmiljö.
+Den här mappen innehåller **produktionsklart material** för att facilitera workshops om AI-agenter, agentifiering och generativ AI.
+
+**Regler för denna mapp:**
+- ✅ Endast genomarbetade och testade workshops
+- ✅ Material som är redo att användas direkt
+- ❌ Inga utkast eller halvfärdiga idéer (de hör hemma i [04_experiments](../04_experiments/))
 
 ---
 

--- a/02_kunskapsbas/README.md
+++ b/02_kunskapsbas/README.md
@@ -1,9 +1,14 @@
-# 📘 02_kunskapsbas – Vår gemensamma förståelse för agentifiering
+# 📘 02_kunskapsbas – Vår bearbetade förståelse
 
-Det här är vår **egna beskrivning av hur vi tänker kring AI-agenter, prompt engineering, språkmodeller och agentifierade system.**  
-Här formulerar vi det vi själva förstår – för att lära, förklara och bygga vidare. Allt som skrivs här är vårt språk, våra begrepp, våra ramar.
+**Här formulerar vi vår egen kunskap** om AI-agenter, agentifiering och generativ AI.
 
-Det är inte en samling länkar. Det är **ett sätt att tänka tillsammans.** 🧠
+**Viktigt:**
+- ✅ Vår egen bearbetade förståelse
+- ✅ Koncept vi själva formulerat och testat
+- ❌ Inte copy-paste från externa källor
+- ❌ Inte bara länkar (de hör hemma i [03_resources](../03_resources/))
+
+**Framtid:** Kommer växa från "AI-agenter" till bredare "Generativ AI"-perspektiv.
 
 ---
 

--- a/04_experiments/README.md
+++ b/04_experiments/README.md
@@ -1,10 +1,19 @@
-# 🧪 04_experiments – Testyta för promptar, agenter och idéfragment
+# 🧪 04_experiments – Dumpningsplats för länkar och idéer
 
-Den här mappen är till för **allt du vill testa, tänka på, skissa upp, eller snabbt dumpa utan att det ska vara färdigt**.  
-Det är din plats för promptar, agentprototyper, flödesutkast, kodsnuttar, scheman, halva tankar och icke-svar.
+**👉 OSÄKER PÅ VAR NÅGOT HÖR HEMMA? DUMPA DET HÄR!**
 
-**Tänk: anteckningsblock, whiteboard, labb.**  
-Allt är tillåtet – så länge det kan hjälpa dig eller någon annan framåt.
+Det här är vår **sorteringshubb** där allt osorterat material börjar sin resa.
+
+**Workflow:**
+1. 📥 Du dumpar länkar, idéer, tankar här
+2. 🤖 AI-agenter (framtida) analyserar och föreslår rätt plats
+3. 📤 Material flyttas till rätt mapp när det är klart
+
+**Detta är framtidens automatiseringshubb** där AI-agenter kommer att:
+- Kategorisera länkar automatiskt
+- Föreslå om något ska bearbetas till kunskapsbasen
+- Kvalitetsbedöma om något är värt att spara i resources
+- Flagga material som kan bli workshops
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,52 +19,78 @@ Vi gör det här för att vi tror på det. Vi gör det tillsammans. 🚀
 
 ---
 
-## 🔧 Hur vi jobbar
+## 🔧 Hur vi jobbar – från manuellt till automatiserat
 
-Det är jag som har börjat samla och kurera materialet här, och repo:t växer fram stegvis. Om du kan GitHub eller vill lära dig, är du välkommen att bidra direkt. Jag själv lär mig medan jag jobbar i det – så det behöver inte vara perfekt, bara funktionellt.
+**Nuläge:** Jag (Wilhelm) kurerar och bygger strukturen. Repo:t växer organiskt och är inte öppet för alla ännu.
 
-Vill du redigera, men är osäker på hur?  
-→ Använd t.ex. ChatGPT/Codex för att få hjälp direkt i GitHub eller terminal.  
-→ Eller börja med att kolla in GitHubs egna guider och YouTube-kanal – det finns massor att hämta.
+**Så här bidrar du idag:**
+1. Hittar du något intressant? Skicka länken till mig
+2. Osäker på var något hör hemma? → Dumpa i [04_experiments](./04_experiments/)
+3. Jag sorterar och förädlar innehållet till rätt lager
 
----
-
-## 📁 Mappstruktur
-
-### [01_workshops](./01_workshops/)
-Allt som rör faciliterade format: mallar, övningar, guider, agent-canvas, instruktioner.  
-Vi kommer använda denna mapp i olika workshopformat, både internt och externt.
-
-> En undermapp `[01_workshops/projects](./01_workshops/projects/)` kommer innehålla konkreta exempel på agentbyggen, MVP:er och testscenarier.
+**Dit vi är på väg:**
+Ett **intelligent workflow** där AI-agenter känner till våra regler och struktur:
+- Du delar en artikel direkt i ChatGPT/Claude
+- Agenten vet automatiskt var den hör hemma
+- Föreslår kopplingar till befintligt material
+- Flaggar om något behöver bearbetas till kunskapsbasen
 
 ---
 
-### [02_kunskapsbas](./02_kunskapsbas/)
-Här skriver vi ner det vi själva förstår, lär ut och jobbar med:  
-agentdefinitioner, promptlogik, flödesmönster, språkmodeller, arkitekturprinciper.
+## 📁 Mappstruktur – fyra tydliga lager
 
-Detta är vår pedagogiska och praktiska dokumentation 📘
+### [01_workshops](./01_workshops/) – *Production Ready*
+**Färdiga, kvalitetssäkrade workshopmaterial** redo att användas direkt i facilitering.  
+Här ligger endast genomarbetade dokument som är klara för intern eller extern användning.
 
----
-
-### [03_resources](./03_resources/)
-Extern input: länkar, artiklar, videos, papers, kodfragment, API:er.  
-Allt vi vill spara men inte själva skrivit. Det här är vårt referensbibliotek 🔗
+> Kommande: En undermapp `projects/` för konkreta agentbyggen och case studies.
 
 ---
 
-### [04_experiments](./04_experiments/)
-Prompttester, agentutkast, halvfärdiga flöden.  
-Här sparas det vi testar, bygger och vill återkomma till. Inget behöver vara färdigt här 🔬
+### [02_kunskapsbas](./02_kunskapsbas/) – *Vår bearbetade förståelse*
+**Egen kunskap vi formulerat och förädlat** om agenter, agentifiering och generativ AI.  
+Här växer vårt gemensamma språk och våra mentala modeller fram.
+
+> Framöver: Bredare perspektiv på generativ AI, inte bara agenter
+
+---
+
+### [03_resources](./03_resources/) – *Kurerat externt material*
+**Noga utvalda externa resurser** som inspirerar och informerar vårt arbete.  
+Artiklar, videos, case studies – kvalitet över kvantitet.
+
+---
+
+### [04_experiments](./04_experiments/) – *Dumpningsplats & sorteringshubb*
+**Här dumpar du länkar och idéer** – det är här den framtida automatiseringen kommer ske.  
+Osäker på var något hör hemma? Lägg det här så sorterar vi det senare.
+
+🤖 **Framtiden:** Här kommer AI-agenter att sortera och kategorisera automatiskt.
+
+---
+
+## 🤖 Workflow-regler för AI-agenter (under utveckling)
+
+**När du delar via AI-agent ska den veta:**
+- 🎯 **Workshops** = Endast färdiga, produktionsklara dokument
+- 📘 **Kunskapsbas** = Vår bearbetade förståelse, inte copy-paste
+- 🔗 **Resources** = Kurerade externa källor av hög kvalitet
+- 🧪 **Experiments** = Allt osäkert, nytt eller osorterat startar här
+
+**Automatiseringsregler:**
+1. Ny länk → Alltid till experiments först
+2. Agenten analyserar innehåll och föreslår kategori
+3. Om kunskapsbas: Behöver bearbetas, inte bara länkas
+4. Om resources: Kvalitetscheck – är det värt att spara?
 
 ---
 
 ## 🔜 Kommande utveckling
 
-- Vi kan lägga till fler mappar (ex. `public`, `projects`, `integrations`) om behov uppstår.
-- Vi kommer använda vissa av dessa delar direkt i CIT-workshops, dokumentation och pilotprojekt.
-- Vi skapar wikilänkar mellan alla `.md`-filer så det går att navigera oavsett mapp.
-- Vi kommer utvärdera hur detta repo kan bli **en plattform för DDI-agentifiering i större skala**, även utanför CIT.
+- **Bredare perspektiv:** Från "AI-agenter" till hela "Generativ AI"-området
+- **Fler mappar:** Möjligen `public/`, `archive/`, `templates/`
+- **API-integration:** Så att agenter kan lägga till innehåll direkt
+- **Kvalitetssäkring:** Automatisk bedömning av relevans och kvalitet
 
 ---
 


### PR DESCRIPTION
Main README:
- Clarify current manual curation process by Wilhelm
- Emphasize 04_experiments as the dumping ground for links
- Add workflow rules for future AI agents
- Explain the four-layer structure clearly

Individual READMEs:
- 01_workshops: Emphasize production-ready only
- 02_kunskapsbas: Our processed understanding, not copy-paste
- 03_resources: Already simplified (curated external sources)
- 04_experiments: Main dumping ground for automation

Future vision:
- AI agents will know the rules and sort automatically
- Links shared via ChatGPT/Claude will be categorized
- Experiments folder is the automation hub

🤖 Generated with [Claude Code](https://claude.ai/code)